### PR TITLE
Current mysql-client no longer exists -  update to new one

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -10,7 +10,7 @@ BIN_PATH="$BUILD_DIR/bin"
 TMP_PATH="$BUILD_DIR/tmp"
 mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
 
-MYSQL_URL="http://security.debian.org/pool/updates/main/m/mysql-5.5/mysql-client-5.5_5.5.50-0+deb7u2_amd64.deb"
+MYSQL_URL="http://security.debian.org/pool/updates/main/m/mysql-5.5/mysql-client-5.5_5.5.52-0+deb8u1_amd64.deb"
 MYSQL_PKG="$CACHE_DIR/mysql.deb"
 MYSQL_PATH="$TMP_PATH/mysql"
 MYSQL_BINARIES="$MYSQL_PATH/usr/bin"


### PR DESCRIPTION
This is for https://github.com/Shopify/talent-store/pull/1089#issuecomment-253528908

The current `mysql-client` no longer exists -  update to new one.

### Which client to pick?
Browsed clients at http://security.debian.org/pool/updates/main/m/mysql-5.5/

Current: `mysql-client-5.5_5.5.50-0+deb7u2_amd64.deb`
 - no longer exists

Chose: `mysql-client-5.5_5.5.52-0+deb8u1_amd64.deb` (thanks for the advice @shivnagarajan )

**`deb7` vs `deb8`?**
Going with deb8 instead of deb7 as deb7 is `obsolete stable release` whereas deb8 is `current stable release`. 

r: @shivnagarajan @kevinhughes27 