### PR TITLE
Ruby implementation without hardcoded version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+before_install:
+  - gem install bundler
+rvm:
+  - '2.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+group :development, :test do
+  gem "rspec"
+  gem "pry"
+  gem "webmock"
+  gem "rake"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,46 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    coderay (1.1.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    diff-lcs (1.2.5)
+    hashdiff (0.2.3)
+    method_source (0.8.2)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    rake (10.5.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    safe_yaml (1.0.4)
+    slop (3.6.0)
+    webmock (1.22.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pry
+  rake
+  rspec
+  webmock
+
+BUNDLED WITH
+   1.13.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/bin/compile
+++ b/bin/compile
@@ -1,31 +1,12 @@
-#!/usr/bin/env bash
-# bin/compile <build-dir> <cache-dir>
+#!/usr/bin/env ruby
 
-set -e
+# sync output
+$stdout.sync = true
 
-BUILD_DIR=$1
-CACHE_DIR=$2
+require_relative "../lib/build_pack"
 
-BIN_PATH="$BUILD_DIR/bin"
-TMP_PATH="$BUILD_DIR/tmp"
-mkdir -p $CACHE_DIR $BIN_PATH $TMP_PATH
+build_dir = ARGV[0]
+cache_dir = ARGV[1]
 
-MYSQL_URL="http://security.debian.org/pool/updates/main/m/mysql-5.5/mysql-client-5.5_5.5.52-0+deb8u1_amd64.deb"
-MYSQL_PKG="$CACHE_DIR/mysql.deb"
-MYSQL_PATH="$TMP_PATH/mysql"
-MYSQL_BINARIES="$MYSQL_PATH/usr/bin"
+BuildPack.run(build_dir, cache_dir)
 
-if [ -f $MYSQL_PKG ]; then
-  echo "-----> Using MySQL Client package from cache"
-else
-  echo "-----> Downloading MySQL Client package"
-  curl $MYSQL_URL -L -s -o $MYSQL_PKG
-fi
-
-echo "-----> Installing MySQL Client"
-dpkg -x $MYSQL_PKG $MYSQL_PATH
-chmod +x $MYSQL_BINARIES/*
-mv $MYSQL_BINARIES/* $BIN_PATH/
-
-echo "-----> Cleaning up"
-rm -rf $MYSQL_PATH

--- a/lib/build_pack.rb
+++ b/lib/build_pack.rb
@@ -1,0 +1,9 @@
+require_relative "build_pack/installer"
+require_relative "build_pack/downloader"
+require_relative "build_pack/logger"
+
+module BuildPack
+  def self.run(build_dir, cache_dir)
+    Installer.install(build_dir, cache_dir)
+  end
+end

--- a/lib/build_pack/downloader.rb
+++ b/lib/build_pack/downloader.rb
@@ -1,0 +1,44 @@
+require 'net/http'
+
+module BuildPack
+  class Downloader
+    MYSQL_BASE_URL = "http://security.debian.org/pool/updates/main/m/mysql-5.5/"
+
+    # example client: "mysql-client-5.5_5.5.52-0+deb8u1_amd64.deb"
+    REGEX = /.*(mysql-client-5\.5_5\.5\.\d\d-0\+deb.u._amd64.deb).*/
+
+    class << self
+      def download_latest_client_to(path)
+        Logger.log_header("Downloading MySQL Client package")
+
+        client = most_recent_client
+
+        if client.empty?
+          Logger.log("No suitable clients available")
+          return
+        end
+
+        Logger.log("Selecting: #{client}")
+
+        File.open(path, 'w+').write(Net::HTTP.get(URI.parse("#{MYSQL_BASE_URL}#{client}")))
+      end
+
+      def most_recent_client
+        Logger.log("Looking for clients at: #{MYSQL_BASE_URL}")
+
+        response = Net::HTTP.get(URI.parse("#{MYSQL_BASE_URL}"))
+
+        Logger.log("available clients:")
+        most_recent = ""
+        response.lines.each do |line|
+          if REGEX =~ line
+            Logger.log("#{$1}")
+            most_recent = $1 if $1 > most_recent
+          end
+        end
+
+        most_recent
+      end
+    end
+  end
+end

--- a/lib/build_pack/installer.rb
+++ b/lib/build_pack/installer.rb
@@ -1,0 +1,74 @@
+require 'fileutils'
+
+module BuildPack
+  class Installer
+    class << self
+
+      def install(build_dir, cache_dir)
+        init_paths(build_dir, cache_dir)
+        make_dirs
+        Downloader.download_latest_client_to(@mysql_pkg) unless cached?
+        if client_exists?
+          install_client and cleanup
+        else
+          fail_install
+        end
+      end
+
+      private
+
+      def init_paths(build_dir, cache_dir)
+        @bin_path = "#{build_dir}/bin"
+        @tmp_path = "#{build_dir}/tmp"
+        @mysql_path = "#{@tmp_path}/mysql"
+        @mysql_binaries = "#{@mysql_path}/usr/bin"
+        @mysql_pkg = "#{cache_dir}/mysql.deb"
+      end
+
+      def make_dirs
+        FileUtils.mkdir_p(@bin_path)
+        FileUtils.mkdir_p(@tmp_path)
+      end
+
+      def cached?
+        if exists = client_exists?
+          Logger.log_header("Using MySQL Client package from cache")
+        end
+
+        exists
+      end
+
+      def client_exists?
+        File.exist?(@mysql_pkg)
+      end
+
+      def install_client
+        run_command_with_message(command: "dpkg -x #{@mysql_pkg} #{@mysql_path}", message: "Installing MySQL Client")
+        fix_perms_and_mv_binaries
+      end
+
+      def run_command_with_message(command:, message:)
+        Logger.log_header("#{message}")
+        Logger.log("#{command}")
+        output = `#{command}`
+        puts output
+      end
+
+      def fix_perms_and_mv_binaries
+        binaries = Dir.glob("#{@mysql_binaries}/*")
+        FileUtils.chmod("u=wrx", binaries)
+        FileUtils.mv(binaries, @bin_path)
+      end
+
+      def cleanup
+        Logger.log_header("Cleaning up")
+        FileUtils.remove_dir(@mysql_path)
+      end
+
+      def fail_install
+        Logger.log_header("Failing mysql client installation as no suitable clients were found")
+        exit 1
+      end
+    end
+  end
+end

--- a/lib/build_pack/logger.rb
+++ b/lib/build_pack/logger.rb
@@ -1,0 +1,11 @@
+module BuildPack
+  class Logger
+    def self.log(message)
+      puts "       #{message}"
+    end
+
+    def self.log_header(message)
+      puts "-----> #{message}"
+    end
+  end
+end

--- a/spec/build_pack/downloader_spec.rb
+++ b/spec/build_pack/downloader_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe BuildPack::Downloader do
+  context "when there are several packages available" do
+    it "picks the most recent amd64 package" do
+      stub_request_to_debian_base_url(Helpers::RESPONSE_WITH_SUITABLE_CLIENTS)
+
+      expect(BuildPack::Downloader.most_recent_client).to eql("#{Helpers::EXPECTED_PACKAGED}")
+    end
+  end
+end

--- a/spec/build_pack/installer_spec.rb
+++ b/spec/build_pack/installer_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+TMP_DIR = "tmp"
+CACHE_DIR = "#{TMP_DIR}/cache_dir"
+BUILD_DIR = "#{TMP_DIR}/build_dir"
+DPKG_BIN_DIR = "#{BUILD_DIR}/tmp/mysql/usr/bin"
+DPKG_BIN_OUTPUT = "#{DPKG_BIN_DIR}/fake_binary"
+MYSQL_INSTALLED_BINARY = "#{BUILD_DIR}/bin/fake_binary"
+
+EXPECTED_DEB_COMMAND = "dpkg -x #{CACHE_DIR}/mysql.deb #{BUILD_DIR}/tmp/mysql"
+STUBBED_DEB_COMMAND = "mkdir -p #{DPKG_BIN_DIR}; touch #{DPKG_BIN_OUTPUT}"
+
+describe BuildPack::Installer do
+  before{`mkdir #{TMP_DIR}`}
+  before{`mkdir #{CACHE_DIR}`}
+  before{`mkdir #{BUILD_DIR}`}
+  after{`rm -r #{TMP_DIR}`}
+
+  context "when cache already has client" do
+    before{`touch #{CACHE_DIR}/mysql.deb`}
+
+    it "installs cached client" do
+      expect(described_class).to receive(:`).with(EXPECTED_DEB_COMMAND) {`#{STUBBED_DEB_COMMAND}`}
+
+      BuildPack::Installer.install(BUILD_DIR, CACHE_DIR)
+
+      expect(File.exists?("#{MYSQL_INSTALLED_BINARY}")).to be
+    end
+  end
+
+  context "when cache does not have client " do
+    it "downloads and installs available client" do
+      stub_request_to_debian_base_url(Helpers::RESPONSE_WITH_SUITABLE_CLIENTS)
+      stub_request_for_expected_package
+
+      BuildPack::Installer.install(BUILD_DIR, CACHE_DIR)
+
+      expect(File.exists?("#{MYSQL_INSTALLED_BINARY}")).to be
+    end
+
+    it "it does not attempt to install when there are no available clients" do
+      stub_request_to_debian_base_url(Helpers::RESPONSE_WITHOUT_SUITABLE_CLIENTS)
+
+      expect{BuildPack::Installer.install(BUILD_DIR, CACHE_DIR)}.to raise_error(SystemExit)
+
+      expect(File.exists?("#{MYSQL_INSTALLED_BINARY}")).not_to be
+    end
+
+  end
+end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,0 +1,61 @@
+module Helpers
+
+  EXPECTED_PACKAGED = "mysql-client-5.5_5.5.62-0+deb7u1_amd64.deb"
+
+  RESPONSE_WITH_SUITABLE_CLIENTS =
+  %{
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_ia64.deb">mysql-client-5.5_5.5.47-0+deb7u1_ia64.deb</a></td><td align="right">2016-01-27 20:58  </td><td align="right">2.0M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_kfreebsd-amd64.deb">mysql-client-5.5_5.5.47-0+deb7u1_kfreebsd-amd64.deb</a></td><td align="right">2016-01-27 19:38  </td><td align="right">1.6M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_kfreebsd-i386.deb">mysql-client-5.5_5.5.47-0+deb7u1_kfreebsd-i386.deb</a></td><td align="right">2016-01-27 17:58  </td><td align="right">1.5M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_mips.deb">mysql-client-5.5_5.5.47-0+deb7u1_mips.deb</a></td><td align="right">2016-01-27 22:28  </td><td align="right">1.5M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_mipsel.deb">mysql-client-5.5_5.5.47-0+deb7u1_mipsel.deb</a></td><td align="right">2016-01-27 22:28  </td><td align="right">1.5M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_powerpc.deb">mysql-client-5.5_5.5.47-0+deb7u1_powerpc.deb</a></td><td align="right">2016-01-27 18:28  </td><td align="right">1.3M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_s390.deb">mysql-client-5.5_5.5.47-0+deb7u1_s390.deb</a></td><td align="right">2016-01-27 18:13  </td><td align="right">1.6M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.51-0+deb8u1_amd64.deb">mysql-client-5.5_5.5.51-0+deb8u1_amd64.deb</a></td><td align="right">2016-09-14 06:11  </td><td align="right">1.6M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_s390x.deb">mysql-client-5.5_5.5.47-0+deb7u1_s390x.deb</a></td><td align="right">2016-01-27 18:43  </td><td align="right">1.6M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_sparc.deb">mysql-client-5.5_5.5.47-0+deb7u1_sparc.deb</a></td><td align="right">2016-01-27 23:28  </td><td align="right">1.4M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.62-0+deb7u1_amd64.deb">mysql-client-5.5_5.5.62-0+deb7u1_amd64.deb</a></td><td align="right">2016-09-16 15:07  </td><td align="right">1.7M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb7u1_armel.deb">mysql-client-5.5_5.5.52-0+deb7u1_armel.deb</a></td><td align="right">2016-09-16 18:27  </td><td align="right">1.4M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb7u1_armhf.deb">mysql-client-5.5_5.5.52-0+deb7u1_armhf.deb</a></td><td align="right">2016-09-16 18:27  </td><td align="right">1.4M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb7u1_i386.deb">mysql-client-5.5_5.5.52-0+deb7u1_i386.deb</a></td><td align="right">2016-09-16 16:57  </td><td align="right">1.5M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.50-0+deb8u1_amd64.deb">mysql-client-5.5_5.5.50-0+deb8u1_amd64.deb</a></td><td align="right">2016-09-14 06:11  </td><td align="right">1.6M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_arm64.deb">mysql-client-5.5_5.5.52-0+deb8u1_arm64.deb</a></td><td align="right">2016-09-14 06:26  </td><td align="right">1.4M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_armel.deb">mysql-client-5.5_5.5.52-0+deb8u1_armel.deb</a></td><td align="right">2016-09-14 07:26  </td><td align="right">1.4M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_armhf.deb">mysql-client-5.5_5.5.52-0+deb8u1_armhf.deb</a></td><td align="right">2016-09-16 15:57  </td><td align="right">1.4M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_i386.deb">mysql-client-5.5_5.5.52-0+deb8u1_i386.deb</a></td><td align="right">2016-09-14 05:56  </td><td align="right">1.6M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_kfreebsd-amd64.deb">mysql-client-5.5_5.5.52-0+deb8u1_kfreebsd-amd64.deb</a></td><td align="right">2016-09-14 16:57  </td><td align="right">1.5M</td></tr>
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.52-0+deb8u1_kfreebsd-i386.deb">mysql-client-5.5_5.5.52-0+deb8u1_kfreebsd-i386.deb</a></td><td align="right">2016-09-14 17:12  </td><td align="right">1.6M</td></tr>
+  }
+
+RESPONSE_WITHOUT_SUITABLE_CLIENTS =
+  %{
+  <tr><td valign="top"><img src="/icons/unknown.gif" alt="[   ]"></td><td><a href="mysql-client-5.5_5.5.47-0+deb7u1_ia64.deb">mysql-client-5.5_5.5.47-0+deb7u1_ia64.deb</a></td><td align="right">2016-01-27 20:58  </td><td align="right">2.0M</td></tr>
+  }
+
+  def stub_request_to_debian_base_url(response)
+    stub_request(:get, BuildPack::Downloader::MYSQL_BASE_URL).
+      with(:headers => {
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Host'=>'security.debian.org',
+        'User-Agent'=>'Ruby'}).
+      to_return(
+        :status => 200,
+        :body => response,
+        :headers => {})
+  end
+
+  def stub_request_for_expected_package
+    stub_request(:get, "#{BuildPack::Downloader::MYSQL_BASE_URL}#{EXPECTED_PACKAGED}").
+      with(:headers => {
+        'Accept'=>'*/*',
+        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        'Host'=>'security.debian.org',
+        'User-Agent'=>'Ruby'}).
+      to_return(
+        :status => 200,
+        :body => "fake binary data",
+        :headers => {})
+        expect(described_class).to receive(:`).with(EXPECTED_DEB_COMMAND) { `#{STUBBED_DEB_COMMAND}` }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+require 'build_pack'
+require 'pry'
+require 'webmock/rspec'
+require 'helpers'
+
+def suppress_output(config)
+  config.before { allow($stdout).to receive(:puts) }
+end
+
+RSpec.configure do |config|
+  suppress_output(config)
+  config.include Helpers
+end


### PR DESCRIPTION
Ruby implementation with rspec tests and Travis CI.

Also, and perhaps most importantly, the mysql version is no longer hardcoded. Instead, a regex match is performed to detect the compatible versions, then the "most recent" is picked doing simple string comparison.

Sample output:

```
remote: -----> MySQL Client app detected        
remote: -----> Downloading MySQL Client package        
remote:        Looking for clients at: http://security.debian.org/pool/updates/main/m/mysql-5.5/
remote:        available clients:        
remote:        mysql-client-5.5_5.5.52-0+deb7u1_amd64.deb        
remote:        mysql-client-5.5_5.5.52-0+deb8u1_amd64.deb        
remote:        Selecting: mysql-client-5.5_5.5.52-0+deb8u1_amd64.deb        
remote: -----> Installing MySQL Client        
remote:        dpkg -x /app/tmp/cache/mysql.deb /tmp/build_1907e74613598acb5986d8dc12bb2564/tmp/mysql        
remote: 
remote: -----> Cleaning up        
```

Full Disclosure: This is my first ruby project (in like 5 years), so it might not be idiomatic, files might need to be moved around, etc...

r: @SebastianSzturo @kevinhughes27 